### PR TITLE
Add live mode

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -2,9 +2,5 @@
   "esnext": true,
   "browser": true,
   "browserify": true,
-  "devel": true,
-  "globals": {
-    "AudioContext": true,
-    "webkitAudioContext": true
-  }
+  "devel": true
 }

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License
 
-Copyright (c) 2015 Igor Null <m1el.2027@gmail.com>
+Copyright (c) 2015 Igor Null <m1el.2027@gmail.com>, Chad von Nau <chad@vonnau.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Readme.md
+++ b/Readme.md
@@ -18,7 +18,8 @@ Code is available under MIT license.
     woscope({
         canvas: myCanvas,
         audio: myAudio,
-        callback: function () { myAudio.play(); }
+        callback: function () { myAudio.play(); },
+        error: function (msg) { console.log('woscope error:', msg); }
     });
 </script>
 ```

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "woscope",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "oscilloscope emulator",
   "homepage": "https://m1el.github.io/woscope/",
   "license": "MIT",

--- a/bower.json
+++ b/bower.json
@@ -10,7 +10,8 @@
     "webgl"
   ],
   "authors": [
-    "m1el"
+    "m1el",
+    "cvn"
   ],
   "ignore": [
     "**/.*"

--- a/demo/index.js
+++ b/demo/index.js
@@ -60,9 +60,11 @@ window.onload = function() {
       callback: function () { htmlAudio.play(); },
       error: function (msg) { htmlError.innerHTML = msg; },
       color: [1/32, 1, 1/32, 1],
+      color2: [1, 0, 1, 1],
       background: [0, 0, 0, 1],
       swap: query.swap,
       invert: query.invert,
+      sweep: query.sweep,
       bloom: query.bloom,
     });
 
@@ -71,6 +73,7 @@ window.onload = function() {
         {
             swap: 'swap channels',
             invert: 'invert coordinates',
+            sweep: 'traditional oscilloscope display',
             bloom: 'add glow',
         }
     );

--- a/demo/index.js
+++ b/demo/index.js
@@ -60,7 +60,8 @@ window.onload = function() {
       callback: function () { htmlAudio.play(); },
       error: function (msg) { htmlError.innerHTML = msg; },
       swap: query.swap,
-      invert: query.invert
+      invert: query.invert,
+      bloom: query.bloom,
     });
 };
 

--- a/demo/index.js
+++ b/demo/index.js
@@ -43,7 +43,8 @@ let file = query.file;
 
 window.onload = function() {
     let canvas = $('c'),
-        htmlAudio = $('htmlAudio');
+        htmlAudio = $('htmlAudio'),
+        htmlError = $('htmlError');
 
     updatePageInfo();
 
@@ -57,6 +58,7 @@ window.onload = function() {
       canvas: canvas,
       audio: htmlAudio,
       callback: function () { htmlAudio.play(); },
+      error: function (msg) { htmlError.innerHTML = msg; },
       swap: query.swap,
       invert: query.invert
     });

--- a/demo/index.js
+++ b/demo/index.js
@@ -59,6 +59,7 @@ window.onload = function() {
       audio: htmlAudio,
       callback: function () { htmlAudio.play(); },
       error: function (msg) { htmlError.innerHTML = msg; },
+      color: [1/32, 1, 1/32, 1],
       background: [0, 0, 0, 1],
       swap: query.swap,
       invert: query.invert,

--- a/demo/index.js
+++ b/demo/index.js
@@ -59,6 +59,7 @@ window.onload = function() {
       audio: htmlAudio,
       callback: function () { htmlAudio.play(); },
       error: function (msg) { htmlError.innerHTML = msg; },
+      background: [0, 0, 0, 1],
       swap: query.swap,
       invert: query.invert,
       bloom: query.bloom,

--- a/demo/index.js
+++ b/demo/index.js
@@ -54,7 +54,7 @@ window.onload = function() {
 
     window.onresize();
 
-    woscope({
+    let myWoscope = woscope({
       canvas: canvas,
       audio: htmlAudio,
       callback: function () { htmlAudio.play(); },
@@ -63,6 +63,15 @@ window.onload = function() {
       invert: query.invert,
       bloom: query.bloom,
     });
+
+    setupOptionsUI(
+        function (options) { Object.assign(myWoscope, options); },
+        {
+            swap: 'swap channels',
+            invert: 'invert coordinates',
+            bloom: 'add glow',
+        }
+    );
 };
 
 window.onresize = function () {
@@ -125,4 +134,25 @@ function updatePageInfo() {
         li.appendChild(a);
         ul.appendChild(li);
     });
+}
+
+function setupOptionsUI(updater, options) {
+    let ul = $('options');
+    ul.innerHTML = '';
+    Object.keys(options).forEach(function (param) {
+        let li = document.createElement('li');
+        li.innerHTML = `<label title="${options[param]}"><input type="checkbox" id="${param}"> ${param}</label>`;
+        let input = li.firstChild.firstChild;
+
+        input.checked = query[param];
+        input.onchange = toggle;
+
+        ul.appendChild(li);
+    });
+
+    function toggle(e) {
+        let result = {};
+        result[e.target.id] = e.target.checked;
+        updater(result);
+    }
 }

--- a/dist/demo.js
+++ b/dist/demo.js
@@ -40,24 +40,43 @@ var file = query.file;
 
 window.onload = function () {
     var canvas = $('c'),
-        htmlAudio = $('htmlAudio');
+        htmlAudio = $('htmlAudio'),
+        htmlError = $('htmlError');
 
     updatePageInfo();
 
     htmlAudio.src = './woscope-music/' + (htmlAudio.canPlayType('audio/ogg') ? file : libraryDict[file].mpeg);
     htmlAudio.load();
-    htmlAudio.volume = 0.5;
 
     window.onresize();
 
-    woscope({
+    var myWoscope = woscope({
         canvas: canvas,
         audio: htmlAudio,
         callback: function callback() {
             htmlAudio.play();
         },
+        error: function error(msg) {
+            htmlError.innerHTML = msg;
+        },
+        color: [1 / 32, 1, 1 / 32, 1],
+        color2: [1, 0, 1, 1],
+        background: [0, 0, 0, 1],
         swap: query.swap,
-        invert: query.invert
+        invert: query.invert,
+        sweep: query.sweep,
+        bloom: query.bloom,
+        live: query.live
+    });
+
+    setupOptionsUI(function (options) {
+        Object.assign(myWoscope, options);
+    }, {
+        swap: 'swap channels',
+        invert: 'invert coordinates',
+        sweep: 'traditional oscilloscope display',
+        bloom: 'add glow',
+        live: 'analyze audio in real time\n\n' + '- no display while paused/scrubbing\n' + '- volume affects the display size\n' + '- does not work in Mobile Safari'
     });
 };
 
@@ -114,53 +133,92 @@ function updatePageInfo() {
             li = document.createElement('li');
         a.appendChild(document.createTextNode(song.title));
 
-        var q = { file: song.file };
-        if (song.swap) {
-            q.swap = true;
-        }
-        if (song.invert) {
-            q.invert = true;
-        }
-        a.href = '?' + dumpq(q);
+        a.href = '?' + dumpq(makeQuery(song));
 
         li.appendChild(a);
         ul.appendChild(li);
     });
 }
 
+function makeQuery(song) {
+    var q = { file: song.file };
+    if (song.swap) {
+        q.swap = true;
+    }
+    if (song.invert) {
+        q.invert = true;
+    }
+    if (query.live) {
+        q.live = true;
+    }
+    return q;
+}
+
+function setupOptionsUI(updater, options) {
+    var ul = $('options');
+    ul.innerHTML = '';
+    Object.keys(options).forEach(function (param) {
+        var li = document.createElement('li');
+        li.innerHTML = '<label title="' + options[param] + '"><input type="checkbox" id="' + param + '"> ' + param + '</label>';
+        var input = li.firstChild.firstChild;
+
+        input.checked = query[param];
+        input.onchange = param === 'live' ? toggleParam : toggle;
+
+        ul.appendChild(li);
+    });
+
+    function toggle(e) {
+        var result = {};
+        result[e.target.id] = e.target.checked;
+        updater(result);
+    }
+    function toggleParam(e) {
+        var q = parseq(location.search);
+        if (!q.file) {
+            q = makeQuery(libraryInfo[0]);
+        }
+        if (e.target.checked) {
+            q[e.target.id] = true;
+        } else {
+            delete q[e.target.id];
+        }
+        location.href = '?' + dumpq(q);
+    }
+}
+
 },{"../":2}],2:[function(require,module,exports){
 'use strict';
 
 var shadersDict = {
-    vsLine: "#define GLSLIFY 1\nprecision highp float;\n#define EPS 1E-6\nuniform float uInvert;\nuniform float uSize;\nattribute vec2 aStart, aEnd;\nattribute float aIdx;\nvarying vec4 uvl;\nvarying float vLen;\nvoid main () {\n    float tang;\n    vec2 current;\n    // All points in quad contain the same data:\n    // segment start point and segment end point.\n    // We determine point position from it's index.\n    float idx = mod(aIdx,4.0);\n    if (idx >= 2.0) {\n        current = aEnd;\n        tang = 1.0;\n    } else {\n        current = aStart;\n        tang = -1.0;\n    }\n    float side = (mod(idx, 2.0)-0.5)*2.0;\n    uvl.xy = vec2(tang, side);\n    uvl.w = floor(aIdx / 4.0 + 0.5);\n\n    vec2 dir = aEnd-aStart;\n    uvl.z = length(dir);\n    if (uvl.z > EPS) {\n        dir = dir / uvl.z;\n    } else {\n    // If the segment is too short draw a square;\n        dir = vec2(1.0, 0.0);\n    }\n    vec2 norm = vec2(-dir.y, dir.x);\n    gl_Position = vec4((current+(tang*dir+norm*side)*uSize)*uInvert,0.0,1.0);\n    //gl_PointSize = 20.0;\n}\n",
-    fsLine: "#define GLSLIFY 1\nprecision highp float;\n#define EPS 1E-6\n#define TAU 6.283185307179586\n#define TAUR 2.5066282746310002\n#define SQRT2 1.4142135623730951\nuniform float uSize;\nuniform float uIntensity;\nprecision highp float;\nvarying vec4 uvl;\nfloat gaussian(float x, float sigma) {\n    return exp(-(x * x) / (2.0 * sigma * sigma)) / (TAUR * sigma);\n}\n\nfloat erf(float x) {\n    float s = sign(x), a = abs(x);\n    x = 1.0 + (0.278393 + (0.230389 + (0.000972 + 0.078108 * a) * a) * a) * a;\n    x *= x;\n    return s - s / (x * x);\n}\nvoid main (void)\n{\n    float len = uvl.z;\n    vec2 xy = vec2((len/2.0+uSize)*uvl.x+len/2.0, uSize*uvl.y);\n    float alpha;\n\n    float sigma = uSize/4.0;\n    if (len < EPS) {\n    // If the beam segment is too short, just calculate intensity at the position.\n        alpha = exp(-pow(length(xy),2.0)/(2.0*sigma*sigma))/2.0/sqrt(uSize);\n    } else {\n    // Otherwise, use analytical integral for accumulated intensity.\n        alpha = erf((len-xy.x)/SQRT2/sigma) + erf(xy.x/SQRT2/sigma);\n        alpha *= exp(-xy.y*xy.y/(2.0*sigma*sigma))/2.0/len*uSize;\n    }\n    float afterglow = smoothstep(0.0, 0.33, uvl.w/2048.0);\n    alpha *= afterglow * uIntensity;\n    gl_FragColor = vec4(1./32., 1.0, 1./32., alpha);\n}\n",
-    vsBlurTranspose: "#define GLSLIFY 1\nprecision highp float;\nuniform float uSize;\nattribute vec2 aPos, aST;\nvarying vec2 vTexCoord;\nvoid main (void) {\n    gl_Position = vec4(aPos.y, aPos.x, 1, 1);\n    vTexCoord = aST*uSize/1024.0;\n}\n",
-    fsBlurTranspose: "#define GLSLIFY 1\nprecision highp float;\nuniform sampler2D uTexture;\nuniform float uSize;\nvarying vec2 vTexCoord;\nvoid main (void) {\n    float point = uSize/1024.0/1024.0*2.0;\n    vec4 color = texture2D(uTexture, vTexCoord);\n    float sum = 0.0;\n    sum += texture2D(uTexture, vec2(vTexCoord.x - point*4.0, vTexCoord.y)).g * (1.0/25.0);\n    sum += texture2D(uTexture, vec2(vTexCoord.x - point*3.0, vTexCoord.y)).g * (2.0/25.0);\n    sum += texture2D(uTexture, vec2(vTexCoord.x - point*2.0, vTexCoord.y)).g * (3.0/25.0);\n    sum += texture2D(uTexture, vec2(vTexCoord.x - point*1.0, vTexCoord.y)).g * (4.0/25.0);\n    sum += texture2D(uTexture, vec2(vTexCoord.x            , vTexCoord.y)).g * (5.0/25.0);\n    sum += texture2D(uTexture, vec2(vTexCoord.x + point*1.0, vTexCoord.y)).g * (4.0/25.0);\n    sum += texture2D(uTexture, vec2(vTexCoord.x + point*2.0, vTexCoord.y)).g * (3.0/25.0);\n    sum += texture2D(uTexture, vec2(vTexCoord.x + point*3.0, vTexCoord.y)).g * (2.0/25.0);\n    sum += texture2D(uTexture, vec2(vTexCoord.x + point*4.0, vTexCoord.y)).g * (1.0/25.0);\n    gl_FragColor = vec4(0.0, sum, 0.0, 1.0);\n}\n",
-    vsOutput: "#define GLSLIFY 1\nprecision highp float;\nuniform float uSize;\nattribute vec2 aPos, aST;\nvarying vec2 vTexCoord;\nvoid main (void) {\n    gl_Position = vec4(aPos, 1, 1);\n    vTexCoord = aST*uSize/1024.0;\n}\n",
-    fsOutput: "#define GLSLIFY 1\nprecision highp float;\nuniform sampler2D uTexture;\nuniform float uAlpha;\nvarying vec2 vTexCoord;\nvoid main (void) {\n    vec4 color = texture2D(uTexture, vTexCoord);\n    color.a = uAlpha;\n    gl_FragColor = color;\n}\n",
-    vsProgress: "#define GLSLIFY 1\nprecision highp float;\nattribute vec2 aPos;\nattribute vec2 aUV;\nvarying vec2 vUV;\nvoid main (void) {\n    gl_Position = vec4(aPos, 1, 1);\n    vUV = aUV;\n}\n",
-    fsProgress: "#define GLSLIFY 1\nprecision highp float;\nuniform float uProgress;\nvarying vec2 vUV;\nfloat rect(vec2 p, vec2 s) {\n    return max(abs(p.x)-s.x,abs(p.y)-s.y);\n}\nvoid main (void) {\n    float p = clamp(uProgress, 0.0, 1.0);\n    float hw = 300.0;\n    vec2 size = vec2(800.0, 800.0);\n    vec2 c = size / 2.0;\n    vec2 uv = vUV*size - c;\n    float result = min(rect(uv,vec2(hw+5.,25.)),-rect(uv,vec2(hw+10.,30.)));\n    result = max(result,-rect(uv-vec2(hw*(p-1.0),0.0),vec2(hw*p, 20.0)));\n    gl_FragColor = vec4(vec3(0.1, 1.0, 0.1) * clamp(result, 0.0, 1.0), 1.0);\n}\n"
+    vsLine: "precision highp float;\n#define GLSLIFY 1\n#define EPS 1E-6\nuniform float uInvert;\nuniform float uSize;\nattribute vec2 aStart, aEnd;\nattribute float aIdx;\nvarying vec4 uvl;\nvarying float vLen;\nvoid main () {\n    float tang;\n    vec2 current;\n    // All points in quad contain the same data:\n    // segment start point and segment end point.\n    // We determine point position from it's index.\n    float idx = mod(aIdx,4.0);\n    if (idx >= 2.0) {\n        current = aEnd;\n        tang = 1.0;\n    } else {\n        current = aStart;\n        tang = -1.0;\n    }\n    float side = (mod(idx, 2.0)-0.5)*2.0;\n    uvl.xy = vec2(tang, side);\n    uvl.w = floor(aIdx / 4.0 + 0.5);\n\n    vec2 dir = aEnd-aStart;\n    uvl.z = length(dir);\n    if (uvl.z > EPS) {\n        dir = dir / uvl.z;\n    } else {\n    // If the segment is too short draw a square;\n        dir = vec2(1.0, 0.0);\n    }\n    vec2 norm = vec2(-dir.y, dir.x);\n    gl_Position = vec4((current+(tang*dir+norm*side)*uSize)*uInvert,0.0,1.0);\n    //gl_PointSize = 20.0;\n}\n",
+    fsLine: "precision highp float;\n#define GLSLIFY 1\n#define EPS 1E-6\n#define TAU 6.283185307179586\n#define TAUR 2.5066282746310002\n#define SQRT2 1.4142135623730951\nuniform float uSize;\nuniform float uIntensity;\nuniform vec4 uColor;\nvarying vec4 uvl;\nfloat gaussian(float x, float sigma) {\n    return exp(-(x * x) / (2.0 * sigma * sigma)) / (TAUR * sigma);\n}\n\nfloat erf(float x) {\n    float s = sign(x), a = abs(x);\n    x = 1.0 + (0.278393 + (0.230389 + (0.000972 + 0.078108 * a) * a) * a) * a;\n    x *= x;\n    return s - s / (x * x);\n}\nvoid main (void)\n{\n    float len = uvl.z;\n    vec2 xy = vec2((len/2.0+uSize)*uvl.x+len/2.0, uSize*uvl.y);\n    float alpha;\n\n    float sigma = uSize/4.0;\n    if (len < EPS) {\n    // If the beam segment is too short, just calculate intensity at the position.\n        alpha = exp(-pow(length(xy),2.0)/(2.0*sigma*sigma))/2.0/sqrt(uSize);\n    } else {\n    // Otherwise, use analytical integral for accumulated intensity.\n        alpha = erf((len-xy.x)/SQRT2/sigma) + erf(xy.x/SQRT2/sigma);\n        alpha *= exp(-xy.y*xy.y/(2.0*sigma*sigma))/2.0/len*uSize;\n    }\n    float afterglow = smoothstep(0.0, 0.33, uvl.w/2048.0);\n    alpha *= afterglow * uIntensity;\n    gl_FragColor = vec4(vec3(uColor), uColor.a * alpha);\n}\n",
+    vsBlurTranspose: "precision highp float;\n#define GLSLIFY 1\nuniform float uSize;\nattribute vec2 aPos, aST;\nvarying vec2 vTexCoord;\nvoid main (void) {\n    gl_Position = vec4(aPos.y, aPos.x, 1, 1);\n    vTexCoord = aST*uSize/1024.0;\n}\n",
+    fsBlurTranspose: "precision highp float;\n#define GLSLIFY 1\nuniform sampler2D uTexture;\nuniform float uSize;\nvarying vec2 vTexCoord;\nvoid main (void) {\n    float point = uSize/1024.0/1024.0*2.0;\n    vec4 color = texture2D(uTexture, vTexCoord);\n    float sum = 0.0;\n    sum += texture2D(uTexture, vec2(vTexCoord.x - point*4.0, vTexCoord.y)).g * (1.0/25.0);\n    sum += texture2D(uTexture, vec2(vTexCoord.x - point*3.0, vTexCoord.y)).g * (2.0/25.0);\n    sum += texture2D(uTexture, vec2(vTexCoord.x - point*2.0, vTexCoord.y)).g * (3.0/25.0);\n    sum += texture2D(uTexture, vec2(vTexCoord.x - point*1.0, vTexCoord.y)).g * (4.0/25.0);\n    sum += texture2D(uTexture, vec2(vTexCoord.x            , vTexCoord.y)).g * (5.0/25.0);\n    sum += texture2D(uTexture, vec2(vTexCoord.x + point*1.0, vTexCoord.y)).g * (4.0/25.0);\n    sum += texture2D(uTexture, vec2(vTexCoord.x + point*2.0, vTexCoord.y)).g * (3.0/25.0);\n    sum += texture2D(uTexture, vec2(vTexCoord.x + point*3.0, vTexCoord.y)).g * (2.0/25.0);\n    sum += texture2D(uTexture, vec2(vTexCoord.x + point*4.0, vTexCoord.y)).g * (1.0/25.0);\n    gl_FragColor = vec4(0.0, sum, 0.0, 1.0);\n}\n",
+    vsOutput: "precision highp float;\n#define GLSLIFY 1\nuniform float uSize;\nattribute vec2 aPos, aST;\nvarying vec2 vTexCoord;\nvoid main (void) {\n    gl_Position = vec4(aPos, 1, 1);\n    vTexCoord = aST*uSize/1024.0;\n}\n",
+    fsOutput: "precision highp float;\n#define GLSLIFY 1\nuniform sampler2D uTexture;\nuniform float uAlpha;\nvarying vec2 vTexCoord;\nvoid main (void) {\n    vec4 color = texture2D(uTexture, vTexCoord);\n    color.a = uAlpha;\n    gl_FragColor = color;\n}\n",
+    vsProgress: "precision highp float;\n#define GLSLIFY 1\nattribute vec2 aPos;\nattribute vec2 aUV;\nvarying vec2 vUV;\nvoid main (void) {\n    gl_Position = vec4(aPos, 1, 1);\n    vUV = aUV;\n}\n",
+    fsProgress: "precision highp float;\n#define GLSLIFY 1\nuniform float uProgress;\nuniform vec4 uColor;\nvarying vec2 vUV;\nfloat rect(vec2 p, vec2 s) {\n    return max(abs(p.x)-s.x,abs(p.y)-s.y);\n}\nvoid main (void) {\n    float p = clamp(uProgress, 0.0, 1.0);\n    float hw = 300.0;\n    vec2 size = vec2(800.0, 800.0);\n    vec2 c = size / 2.0;\n    vec2 uv = vUV*size - c;\n    float result = min(rect(uv,vec2(hw+5.,25.)),-rect(uv,vec2(hw+10.,30.)));\n    result = max(result,-rect(uv-vec2(hw*(p-1.0),0.0),vec2(hw*p, 20.0)));\n    gl_FragColor = uColor * clamp(result, 0.0, 1.0);\n}\n"
 };
 
-var audioCtx = undefined;
-try {
-    try {
-        audioCtx = new AudioContext();
-    } catch (e) {
-        audioCtx = new webkitAudioContext();
-    }
-} catch (e) {
-    throw new Error('Web Audio API is not supported in this browser');
-}
+var defaultColor = [1 / 32, 1, 1 / 32, 1],
+    defaultBackground = [0, 0, 0, 1];
 
-function axhr(url, callback, progress) {
+var audioCtx = void 0;
+
+function axhr(url, callback, errorCallback, progress) {
     var request = new XMLHttpRequest();
     request.open('GET', url, true);
     request.responseType = 'arraybuffer';
     request.onprogress = progress;
     request.onload = function () {
+        if (request.status >= 400) {
+            return errorCallback("Error loading audio file - " + request.status + " " + request.statusText);
+        }
         audioCtx.decodeAudioData(request.response, function (buffer) {
             callback(buffer);
+        }, function (e) {
+            errorCallback('Unable to decode audio data');
         });
     };
     request.send();
@@ -168,16 +226,24 @@ function axhr(url, callback, progress) {
 
 module.exports = woscope;
 function woscope(config) {
+    audioCtx = audioCtx || initAudioCtx(config.error);
+
     var canvas = config.canvas,
-        gl = initGl(canvas),
+        gl = initGl(canvas, config.background, config.error),
         audio = config.audio,
         audioUrl = config.audioUrl || audio.currentSrc || audio.src,
+        live = config.live === true ? getLiveType() : config.live,
         callback = config.callback || function () {};
 
     var ctx = {
         gl: gl,
+        destroy: destroy,
+        live: live,
         swap: config.swap,
         invert: config.invert,
+        sweep: config.sweep,
+        color: config.color,
+        color2: config.color2,
         lineShader: createShader(gl, shadersDict.vsLine, shadersDict.fsLine),
         blurShader: createShader(gl, shadersDict.vsBlurTranspose, shadersDict.fsBlurTranspose),
         outputShader: createShader(gl, shadersDict.vsOutput, shadersDict.fsOutput),
@@ -185,52 +251,186 @@ function woscope(config) {
         progress: 0,
         loaded: false,
         nSamples: 4096,
-        doBloom: false
+        bloom: config.bloom
     };
 
     Object.assign(ctx, {
         quadIndex: makeQuadIndex(ctx),
         vertexIndex: makeVertexIndex(ctx),
         outQuadArray: makeOutQuad(ctx),
-        scratchBuffer: new Float32Array(ctx.nSamples * 4)
+        scratchBuffer: new Float32Array(ctx.nSamples * 4),
+        audioRamp: makeRamp(Math.ceil(ctx.nSamples / 3))
     });
 
     Object.assign(ctx, makeFrameBuffer(ctx, canvas.width, canvas.height));
 
-    var loop = function loop() {
+    function destroy() {
+        // release GPU in Chrome
+        gl.getExtension('WEBGL_lose_context').loseContext();
+        // end loops, empty context object
+        _loop = emptyContext;
+        _progressLoop = emptyContext;
+        function emptyContext() {
+            Object.keys(ctx).forEach(function (val) {
+                delete ctx[val];
+            });
+        }
+    }
+
+    var _loop = function loop() {
         draw(ctx, canvas, audio);
-        requestAnimationFrame(loop);
+        requestAnimationFrame(_loop);
     };
 
-    var progressLoop = function progressLoop() {
+    if (ctx.live) {
+        if (ctx.live === 'scriptProcessor') {
+            ctx.scriptNode = initScriptNode(ctx, audio, audioCtx);
+        } else {
+            ctx.analysers = initAnalysers(ctx, audio);
+        }
+        callback(ctx);
+        _loop();
+        return ctx;
+    }
+
+    var _progressLoop = function progressLoop() {
         if (ctx.loaded) {
             return;
         }
         drawProgress(ctx, canvas);
-        requestAnimationFrame(progressLoop);
+        requestAnimationFrame(_progressLoop);
     };
-    progressLoop();
+    _progressLoop();
 
     axhr(audioUrl, function (buffer) {
-        callback();
-
         ctx.audioData = prepareAudioData(ctx, buffer);
         ctx.loaded = true;
-        loop();
-    }, function (e) {
+        callback(ctx);
+        _loop();
+    }, config.error, function (e) {
         ctx.progress = e.total ? e.loaded / e.total : 1.0;
         console.log('progress: ' + e.loaded + ' / ' + e.total);
     });
+
+    return ctx;
 }
 
-function initGl(canvas) {
-    var gl = canvas.getContext('webgl');
-    if (!gl) {
-        $('nogl').style.display = 'block';
-        throw new Error('no gl :C');
+function supportsAnalyserFloat() {
+    return typeof audioCtx.createAnalyser().getFloatTimeDomainData === 'function';
+}
+
+function getLiveType() {
+    return supportsAnalyserFloat() ? 'analyser' : 'scriptProcessor';
+}
+
+function initAudioCtx(errorCallback) {
+    try {
+        var AudioCtx = window.AudioContext || window.webkitAudioContext;
+        return new AudioCtx();
+    } catch (e) {
+        var message = 'Web Audio API is not supported in this browser';
+        if (errorCallback) {
+            errorCallback(message);
+        }
+        throw new Error(message);
     }
-    gl.clearColor(0.0, 0.0, 0.0, 1.0);
+}
+
+function initGl(canvas, background, errorCallback) {
+    var gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl');
+    if (!gl) {
+        var message = 'WebGL is not supported in this browser :(';
+        if (errorCallback) {
+            errorCallback(message);
+        }
+        throw new Error(message);
+    }
+    gl.clearColor.apply(gl, background || defaultBackground);
     return gl;
+}
+
+function initAnalysers(ctx, audio) {
+    var sourceNode = audioCtx.createMediaElementSource(audio);
+
+    ctx.audioData = {
+        sourceChannels: sourceNode.channelCount
+    };
+
+    // Split the combined channels
+    var channelSplitter = audioCtx.createChannelSplitter(2);
+    sourceNode.connect(gainWorkaround(channelSplitter, audio));
+
+    var analysers = [0, 1].map(function (val, index) {
+        var analyser = audioCtx.createAnalyser();
+        analyser.fftSize = 2048;
+        channelSplitter.connect(analyser, index, 0);
+        return analyser;
+    });
+
+    var channelMerger = audioCtx.createChannelMerger(2);
+    analysers.forEach(function (analyser, index) {
+        analyser.connect(channelMerger, 0, index);
+    });
+
+    channelMerger.connect(audioCtx.destination);
+    return analysers;
+}
+
+function initScriptNode(ctx, audio, audioCtx) {
+    var sourceNode = audioCtx.createMediaElementSource(audio);
+
+    var samples = 1024;
+    var scriptNode = audioCtx.createScriptProcessor(samples, 2, 2);
+    sourceNode.connect(gainWorkaround(scriptNode, audio));
+
+    var audioData = [new Float32Array(ctx.nSamples), new Float32Array(ctx.nSamples)];
+    ctx.audioData = {
+        left: audioData[0],
+        right: audioData[1],
+        sampleRate: audioCtx.sampleRate,
+        sourceChannels: sourceNode.channelCount
+    };
+
+    function processAudio(e) {
+        var inputBuffer = e.inputBuffer,
+            outputBuffer = e.outputBuffer;
+
+        for (var i = 0; i < inputBuffer.numberOfChannels; i++) {
+            var inputData = inputBuffer.getChannelData(i),
+                outputData = outputBuffer.getChannelData(i);
+
+            // send unprocessed audio to output
+            outputData.set(inputData);
+
+            // append to audioData arrays
+            var channel = audioData[i];
+            // shift forward by x samples
+            channel.set(channel.subarray(inputBuffer.length));
+            // add new samples at end
+            channel.set(inputData, channel.length - inputBuffer.length);
+        }
+    }
+
+    scriptNode.onaudioprocess = processAudio;
+
+    scriptNode.connect(audioCtx.destination);
+    return scriptNode;
+}
+
+function gainWorkaround(node, audio) {
+    // Safari: createMediaElementSource causes output to ignore volume slider,
+    // so match gain to slider as a workaround
+    var gainNode = void 0;
+    if (audioCtx.constructor.name === 'webkitAudioContext') {
+        gainNode = audioCtx.createGain();
+        audio.onvolumechange = function () {
+            gainNode.gain.value = audio.muted ? 0 : audio.volume;
+        };
+        gainNode.connect(node);
+        return gainNode;
+    } else {
+        return node;
+    }
 }
 
 function createShader(gl, vsSource, fsSource) {
@@ -251,10 +451,10 @@ function createShader(gl, vsSource, fsSource) {
     gl.shaderSource(fs, fsSource);
     gl.compileShader(fs);
     if (!gl.getShaderParameter(fs, gl.COMPILE_STATUS)) {
-        var infoLog = gl.getShaderInfoLog(fs);
+        var _infoLog = gl.getShaderInfoLog(fs);
         gl.deleteShader(vs);
         gl.deleteShader(fs);
-        throw new Error('createShader, fragment shader compilation:\n' + infoLog);
+        throw new Error('createShader, fragment shader compilation:\n' + _infoLog);
     }
 
     var program = gl.createProgram();
@@ -268,9 +468,9 @@ function createShader(gl, vsSource, fsSource) {
     gl.linkProgram(program);
 
     if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
-        var infoLog = gl.getProgramInfoLog(program);
+        var _infoLog2 = gl.getProgramInfoLog(program);
         gl.deleteProgram(program);
-        throw new Error('createShader, linking:\n' + infoLog);
+        throw new Error('createShader, linking:\n' + _infoLog2);
     }
 
     return program;
@@ -349,51 +549,85 @@ function makeFrameBuffer(ctx, width, height) {
         lineTexture: makeTargetTexture(gl, frameBuffer.width, frameBuffer.height),
         blurTexture: makeTargetTexture(gl, frameBuffer.width, frameBuffer.height),
         blurTexture2: makeTargetTexture(gl, frameBuffer.width, frameBuffer.height),
-        vbo: gl.createBuffer()
+        vbo: gl.createBuffer(),
+        vbo2: gl.createBuffer()
     };
 }
 
 function prepareAudioData(ctx, buffer) {
     var left = buffer.getChannelData(0),
-        right = buffer.getChannelData(1);
-
-    if (ctx.swap) {
-        var tmp = left;
-        left = right;
-        right = tmp;
-    }
+        right = buffer.numberOfChannels > 1 ? buffer.getChannelData(1) : left;
 
     return {
         left: left,
         right: right,
-        sampleRate: buffer.sampleRate
+        sampleRate: buffer.sampleRate,
+        sourceChannels: buffer.numberOfChannels
     };
 }
 
+function makeRamp(len) {
+    // returns array of "len" length, values linearly increase from -1 to 1
+    var arr = new Float32Array(len),
+        dx = 2 / (len - 1);
+    for (var i = 0; i < len; i++) {
+        arr[i] = i * dx - 1;
+    }
+    return arr;
+}
+
 function loadWaveAtPosition(ctx, position) {
-    var gl = ctx.gl;
     position = Math.max(0, position - 1 / 120);
     position = Math.floor(position * ctx.audioData.sampleRate);
 
     var end = Math.min(ctx.audioData.left.length, position + ctx.nSamples) - 1,
         len = end - position;
-    var subArr = ctx.scratchBuffer,
-        left = ctx.audioData.left,
-        right = ctx.audioData.right;
-    for (var i = 0; i < len; i++) {
-        var t = i * 8,
-            p = i + position;
-        subArr[t] = subArr[t + 2] = subArr[t + 4] = subArr[t + 6] = left[p];
-        subArr[t + 1] = subArr[t + 3] = subArr[t + 5] = subArr[t + 7] = right[p];
-    }
+    var left = ctx.audioData.left.subarray(position, end),
+        right = ctx.audioData.right.subarray(position, end);
 
-    gl.bindBuffer(gl.ARRAY_BUFFER, ctx.vbo);
-    gl.bufferData(gl.ARRAY_BUFFER, subArr, gl.STATIC_DRAW);
-    gl.bindBuffer(gl.ARRAY_BUFFER, null);
+    channelRouter(ctx, len, left, right);
 }
 
-function $(id) {
-    return document.getElementById(id);
+function loadWaveLive(ctx) {
+    var analyser0 = ctx.analysers[0],
+        analyser1 = ctx.analysers[1];
+    var len = analyser0.fftSize,
+        left = new Float32Array(analyser0.fftSize),
+        right = new Float32Array(analyser1.fftSize);
+
+    analyser0.getFloatTimeDomainData(left);
+    analyser1.getFloatTimeDomainData(right);
+
+    channelRouter(ctx, len, left, right);
+}
+
+function channelRouter(ctx, len, left, right) {
+    if (ctx.sweep && ctx.swap) {
+        loadChannelsInto(ctx, len, ctx.vbo, ctx.audioRamp, right);
+        loadChannelsInto(ctx, len, ctx.vbo2, ctx.audioRamp, left);
+    } else if (ctx.sweep) {
+        loadChannelsInto(ctx, len, ctx.vbo, ctx.audioRamp, left);
+        loadChannelsInto(ctx, len, ctx.vbo2, ctx.audioRamp, right);
+    } else if (ctx.swap) {
+        loadChannelsInto(ctx, len, ctx.vbo, right, left);
+    } else {
+        loadChannelsInto(ctx, len, ctx.vbo, left, right);
+    }
+}
+
+function loadChannelsInto(ctx, len, vbo, xAxis, yAxis) {
+    var gl = ctx.gl,
+        subArr = ctx.scratchBuffer;
+
+    for (var i = 0; i < len; i++) {
+        var t = i * 8;
+        subArr[t] = subArr[t + 2] = subArr[t + 4] = subArr[t + 6] = xAxis[i];
+        subArr[t + 1] = subArr[t + 3] = subArr[t + 5] = subArr[t + 7] = yAxis[i];
+    }
+
+    gl.bindBuffer(gl.ARRAY_BUFFER, vbo);
+    gl.bufferData(gl.ARRAY_BUFFER, subArr, gl.STATIC_DRAW);
+    gl.bindBuffer(gl.ARRAY_BUFFER, null);
 }
 
 function supportsWebGl() {
@@ -434,6 +668,10 @@ function drawProgress(ctx, canvas) {
         if (tmpPos && tmpPos !== -1) {
             gl.uniform1f(tmpPos, progress);
         }
+        tmpPos = gl.getUniformLocation(ctx.progressShader, 'uColor');
+        if (tmpPos && tmpPos !== -1) {
+            gl.uniform4fv(tmpPos, ctx.color || defaultColor);
+        }
     }
 
     gl.bindBuffer(gl.ARRAY_BUFFER, ctx.outQuadArray);
@@ -467,23 +705,37 @@ function drawProgress(ctx, canvas) {
 
 function draw(ctx, canvas, audio) {
     var gl = ctx.gl;
-    loadWaveAtPosition(ctx, audio.currentTime);
+    if (ctx.live) {
+        if (ctx.live === 'scriptProcessor') {
+            loadWaveAtPosition(ctx, 0);
+        } else {
+            loadWaveLive(ctx);
+        }
+    } else {
+        loadWaveAtPosition(ctx, audio.currentTime);
+    }
 
     var width = canvas.width,
         height = canvas.height;
 
-    if (!ctx.doBloom) {
+    if (!ctx.bloom) {
         gl.bindFramebuffer(gl.FRAMEBUFFER, null);
         gl.viewport(0, 0, width, height);
         gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
-        drawLine(ctx, ctx.lineShader);
+        drawLine(ctx, ctx.lineShader, ctx.vbo, ctx.color);
+        if (ctx.sweep) {
+            drawLine(ctx, ctx.lineShader, ctx.vbo2, ctx.color2);
+        }
     } else {
 
         gl.bindFramebuffer(gl.FRAMEBUFFER, ctx.frameBuffer);
         activateTargetTexture(ctx, ctx.lineTexture);
         gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
         gl.viewport(0, 0, width, height);
-        drawLine(ctx, ctx.lineShader);
+        drawLine(ctx, ctx.lineShader, ctx.vbo, ctx.color);
+        if (ctx.sweep) {
+            drawLine(ctx, ctx.lineShader, ctx.vbo2, ctx.color2);
+        }
 
         {
             // generate mipmap
@@ -516,7 +768,7 @@ function draw(ctx, canvas, audio) {
     }
 }
 
-function drawLine(ctx, shader) {
+function drawLine(ctx, shader, vbo, color) {
     var gl = ctx.gl;
     gl.useProgram(shader);
     {
@@ -531,6 +783,10 @@ function drawLine(ctx, shader) {
         tmpPos = gl.getUniformLocation(shader, 'uIntensity');
         if (tmpPos && tmpPos !== -1) {
             gl.uniform1f(tmpPos, 1);
+        }
+        tmpPos = gl.getUniformLocation(shader, 'uColor');
+        if (tmpPos && tmpPos !== -1) {
+            gl.uniform4fv(tmpPos, color || defaultColor);
         }
     }
 
@@ -547,19 +803,19 @@ function drawLine(ctx, shader) {
     }
 
     {
-        gl.bindBuffer(gl.ARRAY_BUFFER, ctx.vbo);
-        var tmpPos = gl.getAttribLocation(shader, 'aStart');
-        if (tmpPos > -1) {
-            gl.enableVertexAttribArray(tmpPos);
-            gl.vertexAttribPointer(tmpPos, 2, gl.FLOAT, false, 8, 0);
-            attribs.push(tmpPos);
+        gl.bindBuffer(gl.ARRAY_BUFFER, vbo);
+        var _tmpPos = gl.getAttribLocation(shader, 'aStart');
+        if (_tmpPos > -1) {
+            gl.enableVertexAttribArray(_tmpPos);
+            gl.vertexAttribPointer(_tmpPos, 2, gl.FLOAT, false, 8, 0);
+            attribs.push(_tmpPos);
         }
 
-        tmpPos = gl.getAttribLocation(shader, 'aEnd');
-        if (tmpPos > -1) {
-            gl.enableVertexAttribArray(tmpPos);
-            gl.vertexAttribPointer(tmpPos, 2, gl.FLOAT, false, 8, 8 * 4);
-            attribs.push(tmpPos);
+        _tmpPos = gl.getAttribLocation(shader, 'aEnd');
+        if (_tmpPos > -1) {
+            gl.enableVertexAttribArray(_tmpPos);
+            gl.vertexAttribPointer(_tmpPos, 2, gl.FLOAT, false, 8, 8 * 4);
+            attribs.push(_tmpPos);
         }
     }
 
@@ -607,17 +863,17 @@ function drawTexture(ctx, texture, size, shader, alpha) {
     gl.activeTexture(gl.TEXTURE0);
     gl.bindTexture(gl.TEXTURE_2D, texture);
     {
-        var tmpPos = gl.getUniformLocation(shader, 'uTexture');
-        if (tmpPos && tmpPos !== -1) {
-            gl.uniform1i(tmpPos, 0);
+        var _tmpPos2 = gl.getUniformLocation(shader, 'uTexture');
+        if (_tmpPos2 && _tmpPos2 !== -1) {
+            gl.uniform1i(_tmpPos2, 0);
         }
-        tmpPos = gl.getUniformLocation(shader, 'uSize');
-        if (tmpPos && tmpPos !== -1) {
-            gl.uniform1f(tmpPos, size);
+        _tmpPos2 = gl.getUniformLocation(shader, 'uSize');
+        if (_tmpPos2 && _tmpPos2 !== -1) {
+            gl.uniform1f(_tmpPos2, size);
         }
-        tmpPos = gl.getUniformLocation(shader, 'uAlpha');
-        if (tmpPos && tmpPos !== -1) {
-            gl.uniform1f(tmpPos, alpha);
+        _tmpPos2 = gl.getUniformLocation(shader, 'uAlpha');
+        if (_tmpPos2 && _tmpPos2 !== -1) {
+            gl.uniform1f(_tmpPos2, alpha);
         }
     }
 

--- a/index.html
+++ b/index.html
@@ -6,15 +6,14 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <style>
 html { background: black; color: #ddd; }
-body { max-width: 800px; margin: 0 auto 100px; }
+body { position: relative; max-width: 800px; margin: 0 auto 100px; }
 canvas { display: block; margin: auto; }
 audio { width: 100%; }
 h2 { text-align: center; margin: 5px; }
 ul { text-align: center; font-size: 20px; margin: 5px; padding: 0;}
 li { display: inline; margin: 0 10px 0 10px; }
 a { color: #2d2; }
-.nogl { display: none; }
-noscript, .nogl { position: absolute; width: 800px; padding-top: 200px;
+noscript, .error { position: absolute; width: 100%; top: 200px;
 text-align: center; font-size: 32px; }
 footer { text-align: center; font-size: 18px; }
     </style>
@@ -22,7 +21,7 @@ footer { text-align: center; font-size: 18px; }
 </head>
 <body>
 <noscript>Did you expect this thing to work without js enabled?</noscript>
-<div id="nogl" class="nogl">It seem you don't have a WebGL-capable web browser :(</div>
+<div id="htmlError" class="error"></div>
 <canvas id="c" width=800 height=800></canvas><br>
 <audio controls id="htmlAudio"></audio><br>
 <h2 id="songInfo">song info goes here</h2>

--- a/index.html
+++ b/index.html
@@ -11,11 +11,12 @@ canvas { display: block; margin: auto; }
 audio { width: 100%; }
 h2 { text-align: center; margin: 5px; }
 ul { text-align: center; font-size: 20px; margin: 5px; padding: 0;}
-li { display: inline; margin: 0 10px 0 10px; }
+li { display: inline-block; margin: 0 10px 0 10px; }
 a { color: #2d2; }
 noscript, .error { position: absolute; width: 100%; top: 200px;
 text-align: center; font-size: 32px; }
 footer { text-align: center; font-size: 18px; }
+.options { font-size: 18px; }
     </style>
     <script src="dist/demo.js"> </script>
 </head>
@@ -26,6 +27,7 @@ footer { text-align: center; font-size: 18px; }
 <audio controls id="htmlAudio"></audio><br>
 <h2 id="songInfo">song info goes here</h2>
 <ul id="playList"></ul>
+<ul id="options" class="options"></ul>
 <footer><a href="https://github.com/m1el/woscope">woscope</a> by m1el</footer>
 </body>
 </html>

--- a/index.js
+++ b/index.js
@@ -54,7 +54,7 @@ function woscope(config) {
         progress: 0,
         loaded: false,
         nSamples: 4096,
-        doBloom: false,
+        bloom: config.bloom,
     };
 
     Object.assign(ctx, {
@@ -362,7 +362,7 @@ function draw(ctx, canvas, audio) {
     let width = canvas.width,
         height = canvas.height;
 
-    if (!ctx.doBloom) {
+    if (!ctx.bloom) {
         gl.bindFramebuffer(gl.FRAMEBUFFER, null);
         gl.viewport(0, 0, width, height);
         gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);

--- a/index.js
+++ b/index.js
@@ -81,18 +81,18 @@ function woscope(config) {
     progressLoop();
 
     axhr(audioUrl, function(buffer) {
-        callback();
-
         ctx.audioData = prepareAudioData(ctx, buffer);
         ctx.loaded = true;
+        callback(ctx);
         loop();
-
     },
     config.error,
     function (e) {
         ctx.progress = e.total ? e.loaded / e.total : 1.0;
         console.log('progress: ' + e.loaded + ' / ' + e.total);
     });
+
+    return ctx;
 }
 
 function initAudioCtx(errorCallback) {

--- a/index.js
+++ b/index.js
@@ -48,6 +48,7 @@ function woscope(config) {
 
     let ctx = {
         gl: gl,
+        destroy: destroy,
         swap: config.swap,
         invert: config.invert,
         sweep: config.sweep,
@@ -72,6 +73,17 @@ function woscope(config) {
     });
 
     Object.assign(ctx, makeFrameBuffer(ctx, canvas.width, canvas.height));
+
+    function destroy() {
+        // release GPU in Chrome
+        gl.getExtension('WEBGL_lose_context').loseContext();
+        // end loops, empty context object
+        loop = emptyContext;
+        progressLoop = emptyContext;
+        function emptyContext() {
+            Object.keys(ctx).forEach(function (val) { delete ctx[val]; });
+        }
+    }
 
     let loop = function() {
         draw(ctx, canvas, audio);

--- a/index.js
+++ b/index.js
@@ -13,7 +13,8 @@ let shadersDict = {
     fsProgress: glslify(__dirname + '/shaders/fsProgress.glsl'),
 };
 
-let defaultBackground = [0, 0, 0, 1];
+let defaultColor = [1/32, 1, 1/32, 1],
+    defaultBackground = [0, 0, 0, 1];
 
 let audioCtx;
 
@@ -49,6 +50,7 @@ function woscope(config) {
         gl: gl,
         swap: config.swap,
         invert: config.invert,
+        color: config.color,
         lineShader: createShader(gl, shadersDict.vsLine, shadersDict.fsLine),
         blurShader: createShader(gl, shadersDict.vsBlurTranspose, shadersDict.fsBlurTranspose),
         outputShader: createShader(gl, shadersDict.vsOutput, shadersDict.fsOutput),
@@ -326,6 +328,10 @@ function drawProgress(ctx, canvas) {
         if (tmpPos && tmpPos !== -1) {
             gl.uniform1f(tmpPos, progress);
         }
+        tmpPos = gl.getUniformLocation(ctx.progressShader, 'uColor');
+        if (tmpPos && tmpPos !== -1) {
+            gl.uniform4fv(tmpPos, ctx.color || defaultColor);
+        }
     }
 
     gl.bindBuffer(gl.ARRAY_BUFFER, ctx.outQuadArray);
@@ -422,6 +428,10 @@ function drawLine(ctx, shader) {
         tmpPos = gl.getUniformLocation(shader, 'uIntensity');
         if (tmpPos && tmpPos !== -1) {
             gl.uniform1f(tmpPos, 1);
+        }
+        tmpPos = gl.getUniformLocation(shader, 'uColor');
+        if (tmpPos && tmpPos !== -1) {
+            gl.uniform4fv(tmpPos, ctx.color || defaultColor);
         }
     }
 

--- a/index.js
+++ b/index.js
@@ -13,6 +13,8 @@ let shadersDict = {
     fsProgress: glslify(__dirname + '/shaders/fsProgress.glsl'),
 };
 
+let defaultBackground = [0, 0, 0, 1];
+
 let audioCtx;
 
 function axhr(url, callback, errorCallback, progress) {
@@ -38,7 +40,7 @@ function woscope(config) {
     audioCtx = audioCtx || initAudioCtx(config.error);
 
     let canvas = config.canvas,
-        gl = initGl(canvas, config.error),
+        gl = initGl(canvas, config.background, config.error),
         audio = config.audio,
         audioUrl = config.audioUrl || audio.currentSrc || audio.src,
         callback = config.callback || function () {};
@@ -108,7 +110,7 @@ function initAudioCtx(errorCallback) {
     }
 }
 
-function initGl(canvas, errorCallback) {
+function initGl(canvas, background, errorCallback) {
     let gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl');
     if (!gl) {
         let message = 'WebGL is not supported in this browser :(';
@@ -117,7 +119,7 @@ function initGl(canvas, errorCallback) {
         }
         throw new Error(message);
     }
-    gl.clearColor( 0.0, 0.0, 0.0, 1.0 );
+    gl.clearColor.apply(gl, background || defaultBackground);
     return gl;
 }
 

--- a/index.js
+++ b/index.js
@@ -96,7 +96,7 @@ function woscope(config) {
 }
 
 function initGl(canvas) {
-    let gl = canvas.getContext('webgl');
+    let gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl');
     if (!gl) {
         $('nogl').style.display = 'block';
         throw new Error('no gl :C');

--- a/index.js
+++ b/index.js
@@ -253,12 +253,13 @@ function makeFrameBuffer(ctx, width, height) {
 
 function prepareAudioData(ctx, buffer) {
     let left = buffer.getChannelData(0),
-        right = buffer.getChannelData(1);
+        right = (buffer.numberOfChannels > 1) ? buffer.getChannelData(1) : left;
 
     return {
         left: left,
         right: right,
         sampleRate: buffer.sampleRate,
+        sourceChannels: buffer.numberOfChannels,
     };
 }
 

--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ function axhr(url, callback, progress) {
 module.exports = woscope;
 function woscope(config) {
     let canvas = config.canvas,
-        gl = initGl(canvas),
+        gl = initGl(canvas, config.error),
         audio = config.audio,
         audioUrl = config.audioUrl || audio.currentSrc || audio.src,
         callback = config.callback || function () {};
@@ -95,11 +95,14 @@ function woscope(config) {
     });
 }
 
-function initGl(canvas) {
+function initGl(canvas, errorCallback) {
     let gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl');
     if (!gl) {
-        $('nogl').style.display = 'block';
-        throw new Error('no gl :C');
+        let message = 'WebGL is not supported in this browser :(';
+        if (errorCallback) {
+            errorCallback(message);
+        }
+        throw new Error(message);
     }
     gl.clearColor( 0.0, 0.0, 0.0, 1.0 );
     return gl;
@@ -269,8 +272,6 @@ function loadWaveAtPosition(ctx, position) {
     gl.bufferData(gl.ARRAY_BUFFER, subArr, gl.STATIC_DRAW);
     gl.bindBuffer(gl.ARRAY_BUFFER, null);
 }
-
-function $(id) { return document.getElementById(id); }
 
 function supportsWebGl() {
     // from https://github.com/Modernizr/Modernizr/blob/master/feature-detects/webgl.js

--- a/index.js
+++ b/index.js
@@ -14,15 +14,6 @@ let shadersDict = {
 };
 
 let audioCtx;
-try {
-    try {
-        audioCtx = new AudioContext();
-    } catch(e) {
-        audioCtx = new webkitAudioContext();
-    }
-} catch(e) {
-    throw new Error('Web Audio API is not supported in this browser');
-}
 
 function axhr(url, callback, progress) {
     let request = new XMLHttpRequest();
@@ -39,6 +30,8 @@ function axhr(url, callback, progress) {
 
 module.exports = woscope;
 function woscope(config) {
+    audioCtx = audioCtx || initAudioCtx(config.error);
+
     let canvas = config.canvas,
         gl = initGl(canvas, config.error),
         audio = config.audio,
@@ -93,6 +86,19 @@ function woscope(config) {
         ctx.progress = e.total ? e.loaded / e.total : 1.0;
         console.log('progress: ' + e.loaded + ' / ' + e.total);
     });
+}
+
+function initAudioCtx(errorCallback) {
+    try {
+        let AudioCtx = window.AudioContext || window.webkitAudioContext;
+        return new AudioCtx();
+    } catch(e) {
+        let message = 'Web Audio API is not supported in this browser';
+        if (errorCallback) {
+            errorCallback(message);
+        }
+        throw new Error(message);
+    }
 }
 
 function initGl(canvas, errorCallback) {

--- a/index.js
+++ b/index.js
@@ -378,14 +378,14 @@ function draw(ctx, canvas, audio) {
         gl.bindFramebuffer(gl.FRAMEBUFFER, null);
         gl.viewport(0, 0, width, height);
         gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
-        drawLine(ctx, ctx.lineShader);
+        drawLine(ctx, ctx.lineShader, ctx.vbo, ctx.color);
     } else {
 
         gl.bindFramebuffer(gl.FRAMEBUFFER, ctx.frameBuffer);
         activateTargetTexture(ctx, ctx.lineTexture);
         gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
         gl.viewport(0, 0, width, height);
-        drawLine(ctx, ctx.lineShader);
+        drawLine(ctx, ctx.lineShader, ctx.vbo, ctx.color);
 
         { // generate mipmap
             gl.bindTexture(gl.TEXTURE_2D, ctx.lineTexture);
@@ -417,7 +417,7 @@ function draw(ctx, canvas, audio) {
     }
 }
 
-function drawLine(ctx, shader) {
+function drawLine(ctx, shader, vbo, color) {
     let gl = ctx.gl;
     gl.useProgram(shader);
     {
@@ -435,7 +435,7 @@ function drawLine(ctx, shader) {
         }
         tmpPos = gl.getUniformLocation(shader, 'uColor');
         if (tmpPos && tmpPos !== -1) {
-            gl.uniform4fv(tmpPos, ctx.color || defaultColor);
+            gl.uniform4fv(tmpPos, color || defaultColor);
         }
     }
 
@@ -452,7 +452,7 @@ function drawLine(ctx, shader) {
     }
 
     {
-        gl.bindBuffer(gl.ARRAY_BUFFER, ctx.vbo);
+        gl.bindBuffer(gl.ARRAY_BUFFER, vbo);
         let tmpPos = gl.getAttribLocation(shader, 'aStart');
         if (tmpPos > -1) {
             gl.enableVertexAttribArray(tmpPos);

--- a/index.js
+++ b/index.js
@@ -174,7 +174,8 @@ function initAnalysers(ctx, audio) {
 
     let analysers = [0, 1].map(function (val, index) {
         let analyser = audioCtx.createAnalyser();
-        channelSplitter.connect(analyser, index);
+        analyser.fftSize = 2048;
+        channelSplitter.connect(analyser, index, 0);
         return analyser;
     });
 

--- a/index.js
+++ b/index.js
@@ -15,14 +15,19 @@ let shadersDict = {
 
 let audioCtx;
 
-function axhr(url, callback, progress) {
+function axhr(url, callback, errorCallback, progress) {
     let request = new XMLHttpRequest();
     request.open('GET', url, true);
     request.responseType = 'arraybuffer';
     request.onprogress = progress;
     request.onload = function() {
+        if (request.status >= 400) {
+            return errorCallback(`Error loading audio file - ${request.status} ${request.statusText}`);
+        }
         audioCtx.decodeAudioData(request.response, function(buffer) {
             callback(buffer);
+        }, function (e) {
+            errorCallback('Unable to decode audio data');
         });
     };
     request.send();
@@ -82,7 +87,9 @@ function woscope(config) {
         ctx.loaded = true;
         loop();
 
-    }, function(e) {
+    },
+    config.error,
+    function (e) {
         ctx.progress = e.total ? e.loaded / e.total : 1.0;
         console.log('progress: ' + e.loaded + ' / ' + e.total);
     });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "woscope",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "oscilloscope emulator",
   "homepage": "https://m1el.github.io/woscope/",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "scripts": {
     "demo": "budo demo/:dist/demo.js --live --open",
-    "build": "jshint *.js demo/*.js && browserify demo/ > dist/demo.js && browserify index.js --standalone woscope -p [bannerify --file banner.txt] > dist/woscope.js"
+    "build": "jshint *.js demo/*.js && browserify demo/ > dist/demo.js && browserify index.js --standalone woscope -p [browserify-banner --file banner.txt] > dist/woscope.js"
   },
   "browserify": {
     "transform": [
@@ -37,9 +37,9 @@
   "devDependencies": {
     "babel-preset-es2015": "^6.1.2",
     "babelify": "^7.2.0",
-    "bannerify": "^1.0.1",
     "browserify": "^12.0.1",
-    "budo": "^6.0.1",
+    "browserify-banner": "^1.0.3",
+    "budo": "^9.4.5",
     "glslify": "^2.3.1",
     "jshint": "^2.8.0"
   }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
     "webgl"
   ],
   "author": "m1el",
+  "contributors": [
+    "cvn"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/m1el/woscope.git"

--- a/shaders/fsLine.glsl
+++ b/shaders/fsLine.glsl
@@ -5,7 +5,7 @@ precision highp float;
 #define SQRT2 1.4142135623730951
 uniform float uSize;
 uniform float uIntensity;
-precision highp float;
+uniform vec4 uColor;
 varying vec4 uvl;
 float gaussian(float x, float sigma) {
     return exp(-(x * x) / (2.0 * sigma * sigma)) / (TAUR * sigma);
@@ -34,5 +34,5 @@ void main (void)
     }
     float afterglow = smoothstep(0.0, 0.33, uvl.w/2048.0);
     alpha *= afterglow * uIntensity;
-    gl_FragColor = vec4(1./32., 1.0, 1./32., alpha);
+    gl_FragColor = vec4(vec3(uColor), uColor.a * alpha);
 }

--- a/shaders/fsProgress.glsl
+++ b/shaders/fsProgress.glsl
@@ -1,5 +1,6 @@
 precision highp float;
 uniform float uProgress;
+uniform vec4 uColor;
 varying vec2 vUV;
 float rect(vec2 p, vec2 s) {
     return max(abs(p.x)-s.x,abs(p.y)-s.y);
@@ -12,5 +13,5 @@ void main (void) {
     vec2 uv = vUV*size - c;
     float result = min(rect(uv,vec2(hw+5.,25.)),-rect(uv,vec2(hw+10.,30.)));
     result = max(result,-rect(uv-vec2(hw*(p-1.0),0.0),vec2(hw*p, 20.0)));
-    gl_FragColor = vec4(vec3(0.1, 1.0, 0.1) * clamp(result, 0.0, 1.0), 1.0);
+    gl_FragColor = uColor * clamp(result, 0.0, 1.0);
 }


### PR DESCRIPTION
Hi Igor,

This is a pretty big PR (again), but it started with simple goals:

1. make the scope work with mono files
2. add a "live" mode, where the scope data comes directly from the playing audio

Working on these led to other changes. You can read the commit messages for the details, but it's probably more fun to run the demo first http://cvn.github.io/woscope/. You'll see new options at the bottom of the page.

Please feel free to ask questions or offer critique.

Chad

---

Notes:

* Make sure to run `npm update` after you pull, I updated some of the dependencies.

* There are two parallel implementations of the live mode, one that uses `audioCtx.createAnalyser` and one that uses `audioCtx.createScriptProcessor`. The analyser path is more performant and generally better, but it's not fully supported in Safari. The best I could do with an analyser in Safari looks like this. Notice the jaggies.

    <p align="center"><img src="https://cloud.githubusercontent.com/assets/774864/22493997/8c5da616-e7e8-11e6-9838-8bda803cfdef.png" width="300" /></p>

    So Safari uses the scriptProcessor path instead, and looks great. But if you'd rather not have the [extra code](/m1el/woscope/pull/6/commits/3bdb853) necessary for this, I have another branch that excludes it: [cvn/woscope/analysers](/cvn/woscope/commits/analysers).

* The dist files now have a bunch of variables prepended by _'s. This is mostly due to changes in `babel-preset-es2015`, particularly the `babel-plugin-transform-es2015-block-scoping` submodule. I looked for a way to get back the old behavior, but it involved either adding more babel dependencies or reorganizing code. I didn't think it was worth it, at least for this PR.